### PR TITLE
Fixed typo in listItems documentation.

### DIFF
--- a/docs/data-listitems.md
+++ b/docs/data-listitems.md
@@ -107,7 +107,7 @@ img.square.alt
 img.rectangle.src      (4x3 aspect ratio)
 img.rectangle.alt
 img.landscape-4x3.src
-img.landscape-4x3.src
+img.landscape-4x3.alt
 img.landscape-16x9.src
 img.landscape-16x9.alt
 name.first             (e.g. Junius)


### PR DESCRIPTION
Duplicate `img.landscape-4x3.src` fixed.